### PR TITLE
If type is unset (= CommonJS) esm entry points need explicit file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "@skjnldsv/sanitize-svg",
   "version": "1.0.2",
   "description": "a small script to remove script tags from SVGs",
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.es.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
-      "require": "./dist/index.js"
+      "import": "./dist/index.es.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,12 +26,12 @@ const config = output => ({
 
 export default [
 	{
-		dir: 'dist',
+		file: 'dist/index.cjs',
 		format: 'cjs',
 		sourcemap: true,
 	},
 	{
-		file: 'dist/index.esm.js',
+		file: 'dist/index.es.mjs',
 		format: 'esm',
 		sourcemap: true,
 	},


### PR DESCRIPTION
Node interprets all `.js` files as CommonJS if type is unset (or CommonJS) even if exports is set differently.

Example error:
```
import { sanitizeSVG } from "@skjnldsv/sanitize-svg";
         ^^^^^^^^^^^
SyntaxError: Named export 'sanitizeSVG' not found. The requested module '@skjnldsv/sanitize-svg' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@skjnldsv/sanitize-svg';
const { sanitizeSVG } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
```